### PR TITLE
Add function for editting group

### DIFF
--- a/app/assets/stylesheets/_flash.scss
+++ b/app/assets/stylesheets/_flash.scss
@@ -2,9 +2,9 @@
   color: $white;
   text-align: center;
   &__alert{
-    background-color: red;
+    background-color: $orange;
   }
   &__notice {
-    background-color: $skyblue;
+    background-color: $green;
   }
 }

--- a/app/assets/stylesheets/_sideVar.scss
+++ b/app/assets/stylesheets/_sideVar.scss
@@ -17,6 +17,21 @@
         color:$white;
         font-size: 16px;
         display: inline-block;
+        a {
+        color:$white;
+          &:link  {
+            text-decoration: none;
+          }
+          &:visited   {
+            text-decoration: none;
+          }
+          &:hover {
+            text-decoration: none;
+          }
+          &:active    {
+            text-decoration: none;
+          }
+        }
       }
       &__lists {
           float: right;

--- a/app/assets/stylesheets/_variable.scss
+++ b/app/assets/stylesheets/_variable.scss
@@ -5,3 +5,5 @@ $dark:#333333;
 $gray:#999999;
 $darkgray:#434A54;
 $white:#ffffff;
+$green:#00A070;
+$orange:#F35500;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -20,7 +20,7 @@ class GroupsController < ApplicationController
 
   def edit
     @group = Group.new
-    @group_name = Group.all.find(params[:id]).name
+    @group_name = Group.find(params[:id]).name
   end
 
   def update

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -20,14 +20,15 @@ class GroupsController < ApplicationController
 
   def edit
     @group = Group.new
+    @group_name = Group.all.find(params[:id]).name
   end
 
   def update
-    @group = Group.new(group_params)
-    if @group.save
-      redirect_to root_path, notice: "グループ情報が更新されました。"
+    @group = Group.find(params[:id])
+    if @group.update(group_params)
+      redirect_to root_path, notice: "更新成功！"
     else
-      render edit_group_path
+      redirect_to edit_group_path(params[:id]), alert: "請輸入組名"
     end
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,8 +1,8 @@
 class GroupsController < ApplicationController
   before_action :authenticate_user!, only: :index
+  before_action :set_group, only: [:edit, :update]
 
   def index
-    @groups = current_user.groups
   end
 
   def new
@@ -19,16 +19,13 @@ class GroupsController < ApplicationController
   end
 
   def edit
-    @group = Group.new
-    @group_name = Group.find(params[:id]).name
   end
 
   def update
-    @group = Group.find(params[:id])
     if @group.update(group_params)
       redirect_to root_path, notice: "グループ名を変更しました：更新成功！"
     else
-      redirect_to edit_group_path(params[:id]), alert: "グループ名を入れてください：請輸入組名！"
+      render :edit
     end
   end
 
@@ -37,8 +34,11 @@ class GroupsController < ApplicationController
       params.require(:group).permit(:name, user_ids: [])
   end
 
+  def set_group
+      @group = Group.find(params[:id])
+  end
+
   def move_to_index
       redirect_to action: :index unless user_signed_in?
-      # indexアクションを強制的に実行する
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,7 +2,7 @@ class GroupsController < ApplicationController
   before_action :authenticate_user!, only: :index
 
   def index
-    @groups = Group.all
+    @groups = current_user.groups
   end
 
   def new
@@ -26,9 +26,9 @@ class GroupsController < ApplicationController
   def update
     @group = Group.find(params[:id])
     if @group.update(group_params)
-      redirect_to root_path, notice: "更新成功！"
+      redirect_to root_path, notice: "グループ名を変更しました：更新成功！"
     else
-      redirect_to edit_group_path(params[:id]), alert: "請輸入組名"
+      redirect_to edit_group_path(params[:id]), alert: "グループ名を入れてください：請輸入組名！"
     end
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,8 +1,22 @@
 class MessagesController < ApplicationController
+
   def index
-    @groups = Group.all
+    @groups = current_user.groups
+    @group_members = @groups.find(params[:group_id]).users
+    @messages = Message.new
+    # @users = current_user.groups.user
   end
+
   def create
-    @groups = Group.all
+    @messages = Message.new(messages_params)
+    if @messages.save
+      redirect_to group_messages_path, notice: "メッセージが投稿されました。"
+    else
+      redirect_to group_messages_path, alert: "投稿内容が空欄です。"
+    end
+  end
+  private
+  def messages_params
+    params.require(:message).permit(:msg, :image).merge(user_id: current_user.id, group_id: params[:group_id])
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,2 +1,8 @@
 class MessagesController < ApplicationController
+  def index
+    @groups = Group.all
+  end
+  def create
+    @groups = Group.all
+  end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,14 +2,12 @@ class MessagesController < ApplicationController
 
   def index
     @groups = current_user.groups
-    @group_members = @groups.find(params[:group_id]).users
-    @messages = Message.new
-    # @users = current_user.groups.user
+    @message = Message.new
   end
 
   def create
-    @messages = Message.new(messages_params)
-    if @messages.save
+    @message = Message.new(messages_params)
+    if @message.save
       redirect_to group_messages_path, notice: "メッセージが投稿されました。"
     else
       redirect_to group_messages_path, alert: "投稿内容が空欄です。"

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,4 +2,5 @@ class Message < ApplicationRecord
   belongs_to :group
   belongs_to :user
 
+  validates :msg, presence: true
 end

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -11,7 +11,7 @@
       .chat-group-form__field--left
         %label.chat-group-form__label{for: "group_name"} グループ名
       .chat-group-form__field--right
-        = t.text_field :name, class: "chat-group-form__input", placeholder: "グループ名を入力してください", value: "hello"
+        = t.text_field :name, class: "chat-group-form__input", placeholder: "グループ名を入力してください", value: params[:id]
     .chat-group-form__field.clearfix
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
       /

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -11,7 +11,7 @@
       .chat-group-form__field--left
         %label.chat-group-form__label{for: "group_name"} グループ名
       .chat-group-form__field--right
-        = t.text_field :name, class: "chat-group-form__input", placeholder: "グループ名を入力してください", value: @group_name
+        = t.text_field :name, class: "chat-group-form__input", placeholder: "グループ名を入力してください", value: @group.name
     .chat-group-form__field.clearfix
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
       /

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,6 +1,6 @@
 .chat-group-form
   %h1 チャットグループ編集
-  = form_for(@group, method: :patch) do |t|
+  = form_for(@group, url: {action: :update}, method: :patch) do |t|
     - if @group.errors.any?
       .chat-group-form__errors
         %h2= "#{@group.errors.count}件のエラーが発生しました。"
@@ -11,7 +11,7 @@
       .chat-group-form__field--left
         %label.chat-group-form__label{for: "group_name"} グループ名
       .chat-group-form__field--right
-        = t.text_field :name, class: "chat-group-form__input", placeholder: "グループ名を入力してください", value: params[:id]
+        = t.text_field :name, class: "chat-group-form__input", placeholder: "グループ名を入力してください", value: @group_name
     .chat-group-form__field.clearfix
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
       /

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,28 +1,18 @@
 .wrapper
   .sideVar
-    = render 'sideVar'
+    = render './shared/sideVar'
   .chat
     .header
       .left-header
-        .left-header__title Group Name Test
+        .left-header__title
         %ul.left-header__members
-          %li.member Member :
-          %li.member name1
-          %li.member name2
-      .right-header
-        = link_to edit_group_path(1), class: "right-header__button" do
-          Edit
+          %li.member
     .messages
       .message
         .upper_message
-          .upper_message__user-name Title
-          .upper_message__data 06.09.2017
-        .lower_message test message1 test message1 test message1 test message1
-      .message
-        .upper_message
-          .upper_message__user-name username2
-          .upper_message__data 10.09.2017
-        .lower_message test message2 test message2 test message2 test message2
+          .upper_message__user-name
+          .upper_message__data
+        .lower_message
     .form
 
       %form{ action: "/", method: "post"}

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -14,11 +14,3 @@
           .upper_message__data
         .lower_message
     .form
-
-      %form{ action: "/", method: "post"}
-      %input{ name: "title", class: "form__message", id: "message__content", placeholder: "type your message."}
-        .form__mask
-          %label{for: "message_image", class: "form__mask__image"}
-            %i.fa.fa-picture-o.icon
-            %input{ type: "file", class: "hidden", id: "message_image"}
-      %input{ type: "submit", value: "send", class: "form__submit"}

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,0 +1,34 @@
+.wrapper
+  .sideVar
+    = render './shared/sideVar'
+  .chat
+    .header
+      .left-header
+        .left-header__title Group Name Test
+        %ul.left-header__members
+          %li.member Member :
+          %li.member name1
+          %li.member name2
+      .right-header
+        = link_to edit_group_path(params[:group_id]), class: "right-header__button" do
+          Edit
+    .messages
+      .message
+        .upper_message
+          .upper_message__user-name Title
+          .upper_message__data 06.09.2017
+        .lower_message test message1 test message1 test message1 test message1
+      .message
+        .upper_message
+          .upper_message__user-name username2
+          .upper_message__data 10.09.2017
+        .lower_message test message2 test message2 test message2 test message2
+    .form
+
+      %form{ action: "/", method: "post"}
+      %input{ name: "title", class: "form__message", id: "message__content", placeholder: "type your message."}
+        .form__mask
+          %label{for: "message_image", class: "form__mask__image"}
+            %i.fa.fa-picture-o.icon
+            %input{ type: "file", class: "hidden", id: "message_image"}
+      %input{ type: "submit", value: "send", class: "form__submit"}

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -4,11 +4,12 @@
   .chat
     .header
       .left-header
-        .left-header__title Group Name Test
+        .left-header__title #{@groups.find(params[:group_id]).name}
         %ul.left-header__members
           %li.member Member :
-          %li.member name1
-          %li.member name2
+          - @group_members.each do |t|
+            %li.member
+              = "#{t.name},"
       .right-header
         = link_to edit_group_path(params[:group_id]), class: "right-header__button" do
           Edit
@@ -24,11 +25,10 @@
           .upper_message__data 10.09.2017
         .lower_message test message2 test message2 test message2 test message2
     .form
-
-      %form{ action: "/", method: "post"}
-      %input{ name: "title", class: "form__message", id: "message__content", placeholder: "type your message."}
+      = form_for(@messages, url: {action: :create}) do |f|
+        = f.text_field :msg, class: "form__message", id: "message__content", placeholder: "type your message."
         .form__mask
           %label{for: "message_image", class: "form__mask__image"}
             %i.fa.fa-picture-o.icon
-            %input{ type: "file", class: "hidden", id: "message_image"}
-      %input{ type: "submit", value: "send", class: "form__submit"}
+            = f.file_field :upload, class: "hidden", id: "message_image"
+        = f.submit :Send, class: "form__submit"

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -4,10 +4,10 @@
   .chat
     .header
       .left-header
-        .left-header__title #{@groups.find(params[:group_id]).name}
+        .left-header__title #{current_user.groups.find(params[:group_id]).name}
         %ul.left-header__members
           %li.member Member :
-          - @group_members.each do |t|
+          - current_user.groups.find(params[:group_id]).users.each do |t|
             %li.member
               = "#{t.name},"
       .right-header
@@ -25,7 +25,7 @@
           .upper_message__data 10.09.2017
         .lower_message test message2 test message2 test message2 test message2
     .form
-      = form_for(@messages, url: {action: :create}) do |f|
+      = form_for(@message, url: {action: :create}) do |f|
         = f.text_field :msg, class: "form__message", id: "message__content", placeholder: "type your message."
         .form__mask
           %label{for: "message_image", class: "form__mask__image"}

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -19,11 +19,6 @@
           .upper_message__user-name Title
           .upper_message__data 06.09.2017
         .lower_message test message1 test message1 test message1 test message1
-      .message
-        .upper_message
-          .upper_message__user-name username2
-          .upper_message__data 10.09.2017
-        .lower_message test message2 test message2 test message2 test message2
     .form
       = form_for(@message, url: {action: :create}) do |f|
         = f.text_field :msg, class: "form__message", id: "message__content", placeholder: "type your message."

--- a/app/views/shared/_sideVar.html.haml
+++ b/app/views/shared/_sideVar.html.haml
@@ -1,5 +1,6 @@
 .header
-  %h3.header__name User Name Test
+  %h3.header__name
+    = link_to 'User Name Test', root_path
   %ul.header__lists
     %li.list
       = link_to new_group_path do

--- a/app/views/shared/_sideVar.html.haml
+++ b/app/views/shared/_sideVar.html.haml
@@ -11,5 +11,6 @@
   - @groups.each do |grp|
     .group
       .group__name
-        = link_to grp.name, group_path(grp.id)
-      .group__message Test Message Test Message Test Message
+        = link_to grp.name, group_messages_path(grp.id)
+      .group__message
+        = link_to "comment here...", group_messages_path(grp.id)

--- a/app/views/shared/_sideVar.html.haml
+++ b/app/views/shared/_sideVar.html.haml
@@ -9,7 +9,7 @@
       = link_to edit_user_path(current_user.id) do
         %i.fa.fa-cog.icon
 .groups
-  - @groups.each do |grp|
+  - current_user.groups.each do |grp|
     .group
       .group__name
         = link_to grp.name, group_messages_path(grp.id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root 'groups#index'
   resources :users, only: [:edit, :update]
-  resources :groups, only: [:index, :new, :create, :edit, :update]
+  resources :groups, only: [:index, :new, :create, :edit, :update] do
+    resources :messages, only: [:index, :create]
+  end
 end


### PR DESCRIPTION
# WHAT
修正項目：
・グループ名編集機能を導入
・グループ名編集が失敗した際のフラッシュメッセージ機能実装
追加：
・ログインユーザーに紐づくグループのみを表示
・メッセージ送信機能を実装（画像送信は未実装）

# WHY
グループ名編集機能が必要だったため